### PR TITLE
Header rerendering every click

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "engines": {
     "node": ">=10.0.0"
   },
-  "version": "2.0.4",
+  "version": "2.0.5",
   "repository": {
     "type": "git",
     "url": "git@github.com:avenuecode/react-components.git"

--- a/src/b_SimplePopover/SimplePopover.jsx
+++ b/src/b_SimplePopover/SimplePopover.jsx
@@ -33,7 +33,10 @@ class SimplePopover extends React.Component <Props> {
   }
 
   handleClickOutside(event) {
-    if (this.wrapperRef && !this.wrapperRef.contains(event.target)) {
+    if (this.props.isOpen
+      && this.wrapperRef
+      && !this.wrapperRef.contains(event.target)
+    ) {
       this.props.closeDotMenu();
     }
   }


### PR DESCRIPTION
Avoiding simple popover to call on close when it's already closed which caused parents to change state unnecessary